### PR TITLE
Setting parsl<0.6.0 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     entry_points={
         'console_scripts':['ceci=ceci.main:main']
     },
-    install_requires=['cwlgen','pyyaml','parsl','descformats']
+    install_requires=['cwlgen','pyyaml','parsl<0.6.0','descformats']
 )


### PR DESCRIPTION
This PR adds a version requirement specifying Parsl version < 0.6.0 to avoid breaking changes in the latest release of Parsl