### PR TITLE
add profiling option with --cprofile

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -653,7 +653,7 @@ I currently know about these stages:
             parser.add_argument(f'--{out}')
         parser.add_argument('--config')
         parser.add_argument('--mpi', action='store_true', help="Set up MPI parallelism")
-        parser.add_argument('--pdb' ,action='store_true', help="Run under the python debugger")
+        parser.add_argument('--pdb', action='store_true', help="Run under the python debugger")
         parser.add_argument('--cprofile', action='store', default='', type=str, help="Profile the stage using the python cProfile tool")
         args = parser.parse_args()
         return args


### PR DESCRIPTION
Adds a --cprofile option into a stage, to save and print out a code execution profile.

I chose "--cprofile" rather than the nicer "--profile" as it's less likely to clash with any normal arguments called "profile".