### PR TITLE
Updates setup.py to allow different install requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ python:
   - "3.8"
 
 install:
-  - python setup.py install
-  # For parsl
-  - pip install flask parsl==0.8.0
-  # for CWL
-  - pip install cwlgen==0.4 cwltool==2.0.20200126090152
-  # For code coverage testing
-  - pip install codecov pytest-cov
+  - pip install .[test,cwl,parsl]
 
 # Test three different pipelines
 script:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This is now alpha status.
 ## Install
 
 ```bash
-pip install git+git://github.com/EiffL/python-cwlgen.git
-python setup.py install
+pip install ceci
 ```
+This installs the simplest version of ceci, if you want to be able
+to use the parsl backend, install instead `ceci[parsl]`.
 
 You can then run an example pipeline from the ceci_lib directory using:
 

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,44 @@
 #!/usr/bin/env python
 """
 Lightweight pipeline engine for LSST DESC
-Copyright (c) 2018 LSST DESC
+Copyright (c) 2018-2020 LSST DESC
 http://opensource.org/licenses/MIT
 """
 from setuptools import setup
+from io import open
 
 version = open('./ceci/version.py').read().split('=')[1].strip().strip("'")
+
+# read the contents of the README file
+with open('README.md', encoding="utf-8") as f:
+    long_description = f.read()
 
 setup(
     name='ceci',
     version=version,
     description='Lightweight pipeline engine for LSST DESC',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/LSSTDESC/ceci',
     maintainer='Joe Zuntz',
-    license='MIT',
+    license='BSD',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Development Status :: 3 - Alpha',
     ],
     packages=['ceci', 'ceci.sites'],
     entry_points={
         'console_scripts':['ceci=ceci.main:main']
     },
-    # flask is actually a parsl dependency, but a setuptools bug
-    # means that capitalizing "Flask" as written in the parsl
-    # setup doesn't work.
-    install_requires=['pyyaml']
+    install_requires=['pyyaml', 'psutil'],
+    extras_require={
+      'parsl': ['flask', 'parsl==0.8.0'],
+      'cwl': ['cwlgen==0.4', 'cwltool==2.0.20200126090152'],
+      'test': ['pytest', 'codecov', 'pytest-cov'],
+      }
 )


### PR DESCRIPTION
This PR aims to fix #30 , with this you can either install a very basic `ceci`, or enable a specific subset of dependencies, such as 
```bash
$ pip install ceci[parsl]
```

@joezuntz just have a look at the setup and see if I have forgotten some important dependencies that should be added but the tests seem to pass :-)