### PR TITLE
Address issue 39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.8"
 
 install:
+  - pip install --upgrade pytest codecov
   - pip install .[test,cwl,parsl]
 
 # Test three different pipelines

--- a/ceci/main.py
+++ b/ceci/main.py
@@ -66,6 +66,8 @@ def run(pipeline_config_filename, extra_config=None, dry_run=False):
     # parsl execution/launcher configuration information
     launcher_config = pipe_config.get("launcher", {"name": "mini"})
     launcher_name = launcher_config["name"]
+    # Launchers may need to know if this is a dry-run
+    launcher_config["dry_run"] = dry_run
 
     # Python modules in which to search for pipeline stages
     modules = pipe_config["modules"].split()

--- a/ceci/sites/__init__.py
+++ b/ceci/sites/__init__.py
@@ -57,10 +57,17 @@ def load(launcher_config, site_configs):
     sites = []
 
     launcher_name = launcher_config["name"]
+    dry_run = launcher_config.get("dry_run", False)
 
     # Create an object for each site.
     for site_config in site_configs:
         site_name = site_config["name"]
+        # Also tell the sites whether this is a dry-run.
+        # for example, the cori site checks you're not
+        # trying to run srun on a login node, but we skip
+        # that test if we are not actually running the command,
+        # just printing it.
+        site_config["dry_run"] = dry_run
 
         try:
             cls = site_classes[site_name]

--- a/ceci/sites/cori.py
+++ b/ceci/sites/cori.py
@@ -35,7 +35,11 @@ class CoriSite(Site):
         if sec.nodes:
             mpi1 += f" --nodes {sec.nodes}"
 
-        if (sec.nprocess > 1) and (os.environ.get("SLURM_JOB_ID") is None):
+        if (
+            (sec.nprocess > 1)
+            and (os.environ.get("SLURM_JOB_ID") is None)
+            and (not self.config.get("dry_run"))
+        ):
             raise ValueError(
                 "You cannot use MPI (by setting nprocess > 1) "
                 "on Cori login nodes, only inside jobs."

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -12,7 +12,6 @@ def test_cori_error():
     launcher_config = {
         "name": "mini",
         "interval": 1.0,
-
     }
     site_config = {
         "name": "cori-interactive",
@@ -32,8 +31,7 @@ def test_cori_error():
         site.command("xxx", sec)
 
     # should work if we do set dry-run
-    launcher_config['dry_run'] = True
+    launcher_config["dry_run"] = True
     load(launcher_config, [site_config])
     site = get_default_site()
     site.command("xxx", sec)
-

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,39 @@
+from ceci.sites import load, get_default_site
+from ceci.pipeline import StageExecutionConfig
+from ceci.main import run
+import pytest
+
+
+def test_cori_error():
+    # check that errors when trying to run multi-process
+    # jobs on cori login nodes are handled correctly.
+    # should fail unless dry-run is set.
+
+    launcher_config = {
+        "name": "mini",
+        "interval": 1.0,
+
+    }
+    site_config = {
+        "name": "cori-interactive",
+    }
+
+    stage_config = {
+        "name": "Test",
+        "nprocess": 2,
+    }
+
+    load(launcher_config, [site_config])
+    site = get_default_site()
+    sec = StageExecutionConfig(stage_config)
+
+    # should fail if we don't set dry-run
+    with pytest.raises(ValueError):
+        site.command("xxx", sec)
+
+    # should work if we do set dry-run
+    launcher_config['dry_run'] = True
+    load(launcher_config, [site_config])
+    site = get_default_site()
+    site.command("xxx", sec)
+


### PR DESCRIPTION
This prevents an error being raised when you try to dry-run a pipeline on cori login nodes.

The errors should be raised when trying to execute a pipeline with multiple processes, because `srun` doesn't work on the login nodes, but if you're just doing dry-run it should behave.

This passes the dry-run status to the launchers and sites.