### PR TITLE
Pass python path to stages

### DIFF
--- a/ceci/main.py
+++ b/ceci/main.py
@@ -72,13 +72,12 @@ def run(pipeline_config_filename, extra_config=None, dry_run=False):
     launcher_config["dry_run"] = dry_run
 
     # Later we will add these paths to sys.path for running here,
-    # but we will also need to pass them to the launcher so that
+    # but we will also need to pass them to the sites below so that
     # they can be added within any containers or other launchers
     # that we use
     paths = pipe_config.get("python_paths", [])
     if isinstance(paths, str):
         paths = paths.split()
-    launcher_config["python_paths"] = paths
 
     # Python modules in which to search for pipeline stages
     modules = pipe_config["modules"].split()
@@ -93,6 +92,8 @@ def run(pipeline_config_filename, extra_config=None, dry_run=False):
     default_site = get_default_site()
 
     site_config = pipe_config.get("site", {"name": "local"})
+    # Pass the paths along to the site
+    site_config["python_paths"] = paths
     load(launcher_config, [site_config])
 
     # Inputs and outputs
@@ -118,6 +119,7 @@ def run(pipeline_config_filename, extra_config=None, dry_run=False):
         "log_dir": pipe_config["log_dir"],
         "resume": pipe_config["resume"],
     }
+
 
     # Choice of actual pipeline type to run
     if dry_run:

--- a/ceci/sites/__init__.py
+++ b/ceci/sites/__init__.py
@@ -58,6 +58,7 @@ def load(launcher_config, site_configs):
 
     launcher_name = launcher_config["name"]
     dry_run = launcher_config.get("dry_run", False)
+    python_paths = launcher_config.get("python_paths", [])
 
     # Create an object for each site.
     for site_config in site_configs:
@@ -68,6 +69,8 @@ def load(launcher_config, site_configs):
         # that test if we are not actually running the command,
         # just printing it.
         site_config["dry_run"] = dry_run
+        # and about any extra paths to add
+        site_config["python_paths"] = python_paths
 
         try:
             cls = site_classes[site_name]

--- a/ceci/sites/__init__.py
+++ b/ceci/sites/__init__.py
@@ -58,7 +58,6 @@ def load(launcher_config, site_configs):
 
     launcher_name = launcher_config["name"]
     dry_run = launcher_config.get("dry_run", False)
-    python_paths = launcher_config.get("python_paths", [])
 
     # Create an object for each site.
     for site_config in site_configs:
@@ -69,8 +68,6 @@ def load(launcher_config, site_configs):
         # that test if we are not actually running the command,
         # just printing it.
         site_config["dry_run"] = dry_run
-        # and about any extra paths to add
-        site_config["python_paths"] = python_paths
 
         try:
             cls = site_classes[site_name]

--- a/ceci/sites/cori.py
+++ b/ceci/sites/cori.py
@@ -31,7 +31,7 @@ class CoriSite(Site):
         mpi1 = f"{self.mpi_command} {sec.nprocess} --cpus-per-task={sec.threads_per_process}"
         mpi2 = f"--mpi" if sec.nprocess > 1 else ""
         volume_flag = f"-V {sec.volume} " if sec.volume else ""
-        paths = self.config["python_paths"]
+        paths = self.config.get("python_paths", [])
 
         if sec.nodes:
             mpi1 += f" --nodes {sec.nodes}"

--- a/ceci/sites/cori.py
+++ b/ceci/sites/cori.py
@@ -31,6 +31,7 @@ class CoriSite(Site):
         mpi1 = f"{self.mpi_command} {sec.nprocess} --cpus-per-task={sec.threads_per_process}"
         mpi2 = f"--mpi" if sec.nprocess > 1 else ""
         volume_flag = f"-V {sec.volume} " if sec.volume else ""
+        paths = self.config["python_paths"]
 
         if sec.nodes:
             mpi1 += f" --nodes {sec.nodes}"
@@ -46,17 +47,38 @@ class CoriSite(Site):
             )
 
         if sec.image:
+            # If we are setting python paths then we have to modify the executable
+            # here.  This is because we need the path to be available right from the
+            # start, in case the stage is defined in a module added by these paths.
+            # The --env flags in docker/shifter overwrites an env var, and there
+            # doesn't seem to be a way to just append to one, so we have to be a bit
+            # roundabout to make this work, and invoke bash -c instead.
+            paths_start = (
+                ("bash -c 'PYTHONPATH=$PYTHONPATH:" + (":".join(paths)))
+                if paths
+                else ""
+            )
+            paths_end = "'" if paths else ""
             return (
                 f"{mpi1} "
                 f"shifter "
                 f"--env OMP_NUM_THREADS={sec.threads_per_process} "
                 f"{volume_flag} "
                 f"--image {sec.image} "
+                f"{paths_start} "
                 f"{cmd} {mpi2} "
+                f"{paths_end} "
             )
         else:
+            paths_env = (
+                ("PYTHONPATH=" + (":".join(paths)) + ":$PYTHONPATH") if paths else ""
+            )
             return (
-                f"OMP_NUM_THREADS={sec.threads_per_process} " f"{mpi1} " f"{cmd} {mpi2}"
+                # In the non-container case this is much easier
+                f"OMP_NUM_THREADS={sec.threads_per_process} "
+                f"{paths_env} "
+                f"{mpi1} "
+                f"{cmd} {mpi2}"
             )
 
     def configure_for_mini(self):

--- a/ceci/sites/local.py
+++ b/ceci/sites/local.py
@@ -31,7 +31,7 @@ class LocalSite(Site):
         mpi1 = f"{self.mpi_command} {sec.nprocess}" if sec.nprocess > 1 else ""
         mpi2 = f"--mpi" if sec.nprocess > 1 else ""
         volume_flag = f"-v {sec.volume} " if sec.volume else ""
-        paths = self.config["python_paths"]
+        paths = self.config.get("python_paths", [])
 
         # TODO: allow other container types here, like singularity
         if sec.image:

--- a/ceci/sites/local.py
+++ b/ceci/sites/local.py
@@ -31,20 +31,40 @@ class LocalSite(Site):
         mpi1 = f"{self.mpi_command} {sec.nprocess}" if sec.nprocess > 1 else ""
         mpi2 = f"--mpi" if sec.nprocess > 1 else ""
         volume_flag = f"-v {sec.volume} " if sec.volume else ""
+        paths = self.config["python_paths"]
 
         # TODO: allow other container types here, like singularity
         if sec.image:
+            # If we are setting python paths then we have to modify the executable
+            # here.  This is because we need the path to be available right from the
+            # start, in case the stage is defined in a module added by these paths.
+            # The --env flags in docker/shifter overwrites an env var, and there
+            # doesn't seem to be a way to just append to one, so we have to be a bit
+            # roundabout to make this work, and invoke bash -c instead.
+            paths_start = (
+                "bash -c 'PYTHONPATH=$PYTHONPATH:" + (":".join(paths)) if paths else ""
+            )
+            paths_end = "'" if paths else ""
             return (
                 f"docker run "
                 f"--env OMP_NUM_THREADS={sec.threads_per_process} "
                 f"{volume_flag} "
                 f"--rm -it {sec.image} "
+                f"{paths_start} "
                 f"{mpi1} "
                 f"{cmd} {mpi2} "
+                f"{paths_end}"
             )
         else:
+            # In the non-container case this is much easier
+            paths_env = (
+                "PYTHONPATH=" + (":".join(paths)) + ":$PYTHONPATH" if paths else ""
+            )
             return (
-                f"OMP_NUM_THREADS={sec.threads_per_process} " f"{mpi1} " f"{cmd} {mpi2}"
+                f"OMP_NUM_THREADS={sec.threads_per_process} "
+                f"{paths_env} "
+                f"{mpi1} "
+                f"{cmd} {mpi2}"
             )
 
     def configure_for_parsl(self):

--- a/ceci/utils.py
+++ b/ceci/utils.py
@@ -1,5 +1,27 @@
 from contextlib import contextmanager
 import sys
+import os
+
+def add_python_path(path, start):
+    # add a path to the env var PYTHONPATH
+    old = os.environ.get("PYTHONPATH", "")
+    if start:
+        new = path + ":" + old
+    else:
+        new = old + ":" + path
+    os.environ['PYTHONPATH'] = new
+
+def remove_python_path(path, start):
+    # remove a path from PYTHONPATH
+    p = os.environ.get("PYTHONPATH", "").split(":")
+    if start:
+        p.remove(path)
+    else:
+        remove_last(p, path)
+    os.environ["PYTHONPATH"] = ":".join(p)
+
+
+
 
 @contextmanager
 def extra_paths(paths, start=True):
@@ -8,7 +30,9 @@ def extra_paths(paths, start=True):
     if isinstance(paths, str):
         paths = paths.split()
 
-    # On enter, add paths to sys.path,
+    # On enter, add paths to both sys.path,
+    # and the PYTHONPATH env var, so that subprocesses
+    # can see it,
     # either the start or the end depending
     # on the start argument
     for path in paths:
@@ -16,6 +40,8 @@ def extra_paths(paths, start=True):
             sys.path.insert(0, path)
         else:
             sys.path.append(path)
+
+        add_python_path(path, start)
 
     # Return control to caller
     try:
@@ -28,6 +54,8 @@ def extra_paths(paths, start=True):
                     sys.path.remove(path)
                 else:
                     remove_last(sys.path, path)
+                # also remove env var entry
+                remove_python_path(path, start)
             # If e.g. user has already done this
             # manually for some reason then just
             # skip

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -191,21 +191,22 @@ MyStage:
             "python_paths": [dirname, mod_dir],
         }
 
+
+        launcher_config = {"interval": 0.5, "name": "mini"}
+        site_config = {"name":"local", "python_paths":[dirname, mod_dir]}
+        load(launcher_config, [site_config])
+
         # note that we don't add the subdir here
         with extra_paths(dirname):
             import my_stage
             print(os.environ["PYTHONPATH"])
             print(sys.path)
             print(os.listdir(dirname))
-            launcher_config = {"interval": 0.5, "name": "mini", "python_paths":[dirname, mod_dir]}
             pipeline = MiniPipeline([{"name": "MyStage"}], launcher_config)
             status = pipeline.run({}, run_config, config_path)
             log = open(dirname + "/MyStage.out").read()
             print(log)
             assert status == 0
-
-
-
 
 
 # this has to be here because we test running the pipeline

--- a/tests/test_python_paths.py
+++ b/tests/test_python_paths.py
@@ -21,15 +21,19 @@ class MyError(Exception):
 def test_extra_paths():
     p = 'xxx111yyy222'
     orig_path = sys.path[:]
+    orig_env = os.environ.get("PYTHONPATH", "")
 
     # check path is put in
     with extra_paths(p):
         assert sys.path[0] == p
+        assert p in os.environ['PYTHONPATH']
 
     # check everything back to normal
     # after with statement
     assert p not in sys.path
     assert sys.path == orig_path
+    assert p not in os.environ['PYTHONPATH']
+    assert os.environ['PYTHONPATH'] == orig_env
 
     # check that an exception does not interfere
     # with this

--- a/tests/test_python_paths.py
+++ b/tests/test_python_paths.py
@@ -2,6 +2,7 @@ import sys
 from ceci.main import run
 from ceci.utils import remove_last, extra_paths
 import pytest
+import os
 
 def test_remove_item():
     l = list('abcdea')


### PR DESCRIPTION
This change makes ceci pass any paths added using the `python_path` configuration option on to any pipeline stages it launches.  To do this it:

-  adds them to the environment variable PYTHONPATH, so that if the module launched with `-m` is found within them then it will be located by the subprocess
- explicitly adds them to the command line to allow container-based launches and copy/pasting from dry runs.

We therefore pass these from the top-level config -> launcher_config -> individual site configs.