### PR TITLE
Two minor fixes

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -308,7 +308,9 @@ I currently know about these stages:
         for out in cls.output_tags():
             parser.add_argument(f"--{out}")
         parser.add_argument("--config")
-        parser.add_argument("--mpi", action="store_true", help="Set up MPI parallelism")
+
+        if cls.parallel:
+            parser.add_argument("--mpi", action="store_true", help="Set up MPI parallelism")
         parser.add_argument(
             "--pdb", action="store_true", help="Run under the python debugger"
         )

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -155,11 +155,10 @@ Missing these names on the command line:
         # where our stage was defined
         filename = sys.modules[cls.__module__].__file__
 
-        # Make sure the pipeline stage has a name
-        if not hasattr(cls, "name"):
-            raise ValueError(
-                f"Pipeline stage defined in {filename} must be given a name."
-            )
+        # Give the stage a name if it doesn't have one already
+        if not hasattr(cls, "name") or cls.name == "PipelineStage":
+            cls.name = cls.__name__
+
         if not hasattr(cls, "outputs"):
             raise ValueError(
                 f"Pipeline stage {cls.name} defined in {filename} must be given a list of outputs."


### PR DESCRIPTION
Fixes two things:

- adds a name if one is not found for a stage
- Removes the --mpi flag when a stage is marked as not parallel

Should merge after the other current PR as it incorporates that (by accident)