### PR TITLE
Enable dask in pipeline stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install
       run: |
-        pip install --upgrade pytest pytest-mock codecov pytest-cov h5py pyyaml
+        pip install --upgrade pytest pytest-mock codecov pytest-cov h5py pyyaml mockmpi
         pip install git+https://github.com/joezuntz/dask-mpi
         pip install .[test,cwl,parsl]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install
       run: |
         pip install --upgrade pytest pytest-mock codecov pytest-cov h5py
+        pip install git+https://github.com/joezuntz/dask-mpi
         pip install .[test,cwl,parsl]
 
     - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install
       run: |
         pip install --upgrade pytest pytest-mock codecov pytest-cov h5py pyyaml mockmpi
+        pip install dask[distributed]
         pip install git+https://github.com/joezuntz/dask-mpi
         pip install .[test,cwl,parsl]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install
       run: |
-        pip install --upgrade pytest pytest-mock codecov pytest-cov h5py
+        pip install --upgrade pytest pytest-mock codecov pytest-cov h5py pyyaml
         pip install git+https://github.com/joezuntz/dask-mpi
         pip install .[test,cwl,parsl]
 

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -546,6 +546,13 @@ I currently know about these stages:
             )
             raise
 
+        if self.size < 3:
+            raise ValueError(
+                "Dask requires at least three processes. One becomes a scheduler "
+                "process, one is a client that runs the code, and more are required "
+                "as worker processes."
+            )
+
         # Cannot specify non-COMM_WORLD communicator here. It wouldn't work anyway.
         # If we want to be able to run things under dask in a library mode
         # while keeping the same MPI comm then we would need to modify the

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -560,7 +560,7 @@ I currently know about these stages:
             )
 
         # This requires my fork until/unless they merge the PR, to allow
-        # us to pass in these two arguents. In vanilla dask-mpi sys.exit
+        # us to pass in these two arguments. In vanilla dask-mpi sys.exit
         # is called at the end of the event loop without returning to us.
         # After this point only a single process, MPI rank 1,
         # should continue to exeute code. The others enter an event

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -532,15 +532,18 @@ I currently know about these stages:
         # env vars seems to work. If the user has already set this then
         # we use that value. Otherwise we only want error logs
         import os
-        key = 'DASK_LOGGING__DISTRIBUTED'
-        os.environ[key] = os.environ.get(key, 'error')
+
+        key = "DASK_LOGGING__DISTRIBUTED"
+        os.environ[key] = os.environ.get(key, "error")
         try:
             import dask
             import dask_mpi
             import dask.distributed
         except ImportError:
-            print("ERROR: Using --mpi option on stages that use dask requires "
-                  "dask[distributed] and dask_mpi to be installed.")
+            print(
+                "ERROR: Using --mpi option on stages that use dask requires "
+                "dask[distributed] and dask_mpi to be installed."
+            )
             raise
 
         # Cannot specify non-COMM_WORLD communicator here. It wouldn't work anyway.
@@ -558,8 +561,6 @@ I currently know about these stages:
         # I don't yet know how to see this dashboard link at nersc
         self.dask_client = dask.distributed.Client()
         print(f"Started dask. Diagnostics at {self.dask_client.dashboard_link}")
-
-
 
     def split_tasks_by_rank(self, tasks):
         """Iterate through a list of items, yielding ones this process is responsible for/

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -1,0 +1,35 @@
+from ceci.stage import PipelineStage
+import mockmpi
+
+def core_dask(comm):
+    class DaskTestStage(PipelineStage):
+        name = "dasktest"
+        dask_parallel = True
+        inputs = []
+        outputs = []
+        config_options = {}
+
+        def run(self):
+            import dask.array as da
+            arr = da.arange(100)
+            x = arr.sum()
+            x = x.compute()
+            assert x == 4950
+
+
+    args = DaskTestStage._parse_command_line(["dasktest", "--config", "tests/config.yml"])
+    DaskTestStage.execute(args, comm=comm)
+
+    # check that all procs get here
+    if comm is not None:
+        comm.Barrier()
+
+
+def test_dask():
+    core_dask(None)
+    mockmpi.mock_mpiexec(3, core_dask)
+    mockmpi.mock_mpiexec(5, core_dask)
+
+
+if __name__ == '__main__':
+    test_dask()


### PR DESCRIPTION
This adds a new parallel option, dask, enabled by setting the class variable `dask_parallel` on a class and running under MPI.

This mode uses dask_mpi to create a client, meaning at least three processes are needed.