### PR TITLE
Add parallel map method

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -783,42 +783,42 @@ I currently know about these stages:
             if i % self.size == self.rank:
                 yield task
 
-    def map_tasks_by_rank(self, function, tasks, allgather=False):
-        """Run a function over a series of tasks in parallel
+    def map_tasks_by_rank(self, function, inputs, allgather=False):
+        """Run a function over a series of inputs, in parallel
 
         This mirrors the map function, and returns the equivalent of
-        [function(task) for task in tasks], but executes in parallel.
+        [function(input) for input in inputs], but executes in parallel.
 
         Parameters
         ----------
         function: Callable
-            Function to be run on tasks
+            Function to be run on each item in inputs
 
-        tasks: Iterable
-            Any sequence of tasks, which should be the same
+        inputs: Iterable
+            Any sequence of inputs, which should be the same
             on all processes. Or at least the same length:
-            tasks not allocated to this process are ignored so
-            you could get away with a dummy task for them.
+            inputs not assigned to this process are ignored so
+            you could get away with a dummy input for them.
 
         allgather: bool
-            Whether to give all ranks the results or just the
-            root process. Default = False.
+            Whether to give all ranks the results (True) or just the
+            root process (False). Default = False.
 
         Returns
         -------
         results: list
-            A list of the results of calling the function on each task,
+            A list of the results of calling the function on each input,
             in the same order as the input tasks
         """
         results = []
-        # We keep track of the number of tasks manually rather
-        # than calling len(tasks) because this allows tasks to
+        # We keep track of the number of inputs manually rather
+        # than calling len(inputs) because this allows inputs to
         # be an iterator.
         n = 0
-        for i, task in enumerate(tasks):
+        for i, inp in enumerate(inputs):
             n += 1
             if i % self.size == self.rank:
-                results.append(function(task))
+                results.append(function(inp))
 
         # If this is running in serial then the above just functions
         # like a basic map or list comprehension.

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -812,7 +812,9 @@ I currently know about these stages:
         for i, task in enumerate(tasks):
             if i % self.size == self.rank:
                 results.append(function(task))
+
         if self.comm is not None:
+            # Collate result as a list-of-lists
             if allgather:
                 collected_results = self.comm.allgather(results)
             else:

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -386,6 +386,40 @@ def test_open_output():
     f.close()
 
 
+def core_test_map(comm):
+    class Kilo(PipelineStage):
+        name = f"Kilo_{comm.size}"
+        inputs = []
+        outputs = []
+        config_options = {"nproc_run": int}
+
+        def run(self):
+            self.power = 2
+            self.my_count = 0
+            x = [1, 2, 3, 4, 5, 6]
+            y = self.map_tasks_by_rank(self.raise_to_power, x, allgather = True)
+            assert y == [1, 4, 9, 16, 25, 36]
+            assert self.my_count == len(x) // self.config["nproc_run"]
+
+            self.power = 3
+            self.my_count = 0
+            y = self.map_tasks_by_rank(self.raise_to_power, x, allgather = True)
+            assert y == [1, 8, 27, 64, 125, 216]
+            assert self.my_count == len(x) // self.config["nproc_run"]
+
+        def raise_to_power(self, x):
+            self.my_count += 1
+            return x ** self.power
+
+    kk = Kilo.make_stage(comm=comm, nproc_run=comm.size)
+    kk.run()
+
+
+def test_map():
+    import mockmpi
+    mockmpi.mock_mpiexec(1, core_test_map)
+    mockmpi.mock_mpiexec(2, core_test_map)
+    mockmpi.mock_mpiexec(3, core_test_map)
 
 
 


### PR DESCRIPTION
This adds a helper method for parallelization, `map_tasks_by_rank` to the base stage.

This is based on Luca's use case in RAIL sed_generator.