### PR TITLE
Show stage name on config error

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -167,8 +167,9 @@ class PipelineStage:
         self._inputs = dict(config=args["config"])
         try:
             self.read_config(args)
-        except:
-            raise RuntimeError(f"Error configuring {self.instance_name} (see above)")
+        except Exception as error:
+            error_class = type(error)
+            raise error_class(f"Error configuring {self.instance_name}: {error.message}")
         self.check_io(args)
 
     def check_io(self, args=None):

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -165,7 +165,10 @@ class PipelineStage:
         # First, we extract configuration information from a combination of
         # command line arguments and optional 'config' file
         self._inputs = dict(config=args["config"])
-        self.read_config(args)
+        try:
+            self.read_config(args)
+        except:
+            raise RuntimeError(f"Error configuring {self.instance_name} (see above)")
         self.check_io(args)
 
     def check_io(self, args=None):

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -169,7 +169,8 @@ class PipelineStage:
             self.read_config(args)
         except Exception as error:
             error_class = type(error)
-            raise error_class(f"Error configuring {self.instance_name}: {error.message}")
+            msg = str(error)
+            raise error_class(f"Error configuring {self.instance_name}: {msg}")
         self.check_io(args)
 
     def check_io(self, args=None):


### PR DESCRIPTION
If there is an error during stage configuration it can sometimes not be clear which stage is the problem. This prints out the error. The original error should be printed above because it is the direct cause of this one.