### PR TITLE
Improve error message when --mpi used incorrectly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,7 @@ jobs:
 
     - name: Tests
       run: |
-        ceci tests/test.yml
-        ceci --dry-run tests/test.yml
-        ceci --flow-chart test-flow.png tests/test.yml
-        test -f test-flow.png
         pytest --cov=ceci
-        # add a test with the memory monitor and profiling switched on
-        python3 -m ceci_example PZEstimationPipe   --DM=./tests/inputs/dm.txt   --fiducial_cosmology=./tests/inputs/fiducial_cosmology.txt   --config=./tests/config.yml   --photoz_pdfs=./tests/outputs/photoz_pdfs.txt --memmon=1 --cprofile=profile.stats
 
 
     - name: Upload coverage to Codecov

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -542,11 +542,6 @@ I currently know about these stages:
             parser.add_argument(
                 "--mpi", action="store_true", help="Set up MPI parallelism"
             )
-        else:
-            if ((cmd is None) and ("--mpi" in sys.argv)) or ("--mpi" in cmd):
-                raise ValueError(
-                    f"Error: you used the --mpi flag (or set MPI parallelism options) for the stage {cls.name}, but that stage cannot be run in parallel."
-                )
 
         parser.add_argument(
             "--pdb", action="store_true", help="Run under the python debugger"
@@ -565,9 +560,20 @@ I currently know about these stages:
             help="Report memory use. Argument gives interval in seconds between reports",
         )
 
+        # Error message we will return if --mpi used on a non-supported
+        # stage.
+        mpi_err = (
+            "Error: you used the --mpi flag (or set MPI parallelism options) "
+            f"for the stage {cls.name}, but that stage cannot be run in parallel."
+        )
+
         if cmd is None:
+            if ("--mpi" in sys.argv) and not cls.parallel:
+                raise ValueError(mpi_err)
             ret_args = parser.parse_args()
         else:
+            if "--mpi" in cmd:
+                raise ValueError(mpi_err)
             ret_args = parser.parse_args(cmd)
 
         return ret_args

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -571,7 +571,7 @@ I currently know about these stages:
                 raise ValueError(mpi_err)
             ret_args = parser.parse_args()
         else:
-            if ("--mpi" in cmd and not cls.parallel):
+            if ("--mpi" in cmd) and not cls.parallel:
                 raise ValueError(mpi_err)
             ret_args = parser.parse_args(cmd)
 

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -572,7 +572,7 @@ I currently know about these stages:
                 raise ValueError(mpi_err)
             ret_args = parser.parse_args()
         else:
-            if "--mpi" in cmd:
+            if ("--mpi" in cmd and not cls.parallel):
                 raise ValueError(mpi_err)
             ret_args = parser.parse_args(cmd)
 

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -542,7 +542,6 @@ I currently know about these stages:
             parser.add_argument(
                 "--mpi", action="store_true", help="Set up MPI parallelism"
             )
-
         parser.add_argument(
             "--pdb", action="store_true", help="Run under the python debugger"
         )

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -544,8 +544,9 @@ I currently know about these stages:
             )
         else:
             if ((cmd is None) and ("--mpi" in sys.argv)) or ("--mpi" in cmd):
-                raise ValueError(f"Error: you used the --mpi flag (or set MPI parallelism options) for the stage {cls.name}, but that stage cannot be run in parallel.")
-
+                raise ValueError(
+                    f"Error: you used the --mpi flag (or set MPI parallelism options) for the stage {cls.name}, but that stage cannot be run in parallel."
+                )
 
         parser.add_argument(
             "--pdb", action="store_true", help="Run under the python debugger"

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -542,6 +542,11 @@ I currently know about these stages:
             parser.add_argument(
                 "--mpi", action="store_true", help="Set up MPI parallelism"
             )
+        else:
+            if ((cmd is None) and ("--mpi" in sys.argv)) or ("--mpi" in cmd):
+                raise ValueError(f"Error: you used the --mpi flag (or set MPI parallelism options) for the stage {cls.name}, but that stage cannot be run in parallel.")
+
+
         parser.add_argument(
             "--pdb", action="store_true", help="Run under the python debugger"
         )

--- a/ceci_example/example_stages.py
+++ b/ceci_example/example_stages.py
@@ -32,6 +32,7 @@ class PZEstimationPipe(PipelineStage):
     name = "PZEstimationPipe"
     inputs = [("DM", TextFile), ("fiducial_cosmology", TextFile)]
     outputs = [("photoz_pdfs", TextFile)]
+    parallel = False
 
     def run(self):
         for inp, _ in self.inputs:

--- a/tests/test_executables.py
+++ b/tests/test_executables.py
@@ -1,0 +1,22 @@
+import pytest
+import subprocess
+import os
+
+def test_executable():
+    subprocess.check_call(["ceci", "tests/test.yml"])
+
+def test_dry_run():
+    subprocess.check_call(["ceci", "--dry-run", "tests/test.yml",])
+
+def test_flow_chart_run():
+    subprocess.check_call(["ceci", "--flow-chart", "test-flow.png", "tests/test.yml",])
+    assert os.path.exists("test-flow.png")
+
+def test_profiling_and_memmon_flags():
+    cmd = "python3 -m ceci_example PZEstimationPipe   --DM=./tests/inputs/dm.txt   --fiducial_cosmology=./tests/inputs/fiducial_cosmology.txt   --config=./tests/config.yml   --photoz_pdfs=./tests/outputs/photoz_pdfs.txt --memmon=1 --cprofile=profile.stats"
+    subprocess.check_call(cmd.split())
+
+def test_misuse_mpi():
+    cmd = "python3 -m ceci_example PZEstimationPipe --mpi"
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(cmd.split())

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -511,8 +511,29 @@ def test_unknown_stage():
         PipelineStage.get_stage("ThisStageIsDeliberatelyLeftBlank")
 
 
+def test_wrong_mpi_flag():
+    class LimaParallel(PipelineStage):
+        name = f"LimaParallel"
+        inputs = []
+        outputs = []
+        config_options = {}
+
+        def run(self):
+            pass
+    class LimaSerial(LimaParallel):
+        name = f"LimaSerial"
+        parallel = False
+
+    assert LimaParallel.parse_command_line(["LimaParallel", "--mpi"]).mpi
+    assert not LimaParallel.parse_command_line(["LimaParallel"]).mpi
+
+    with pytest.raises(ValueError):
+        assert LimaSerial.parse_command_line(["LimaParallel", "--mpi"]).mpi
+
+
 # could add more tests here for constructor, but the regression tests here and in TXPipe are
 # pretty thorough.
 
 if __name__ == "__main__":
     test_construct()
+    test_wrong_mpi_flag()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -512,6 +512,7 @@ def test_unknown_stage():
 
 
 def test_wrong_mpi_flag():
+
     class LimaParallel(PipelineStage):
         name = f"LimaParallel"
         inputs = []
@@ -520,6 +521,7 @@ def test_wrong_mpi_flag():
 
         def run(self):
             pass
+
     class LimaSerial(LimaParallel):
         name = f"LimaSerial"
         parallel = False

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -530,7 +530,7 @@ def test_wrong_mpi_flag():
     assert not LimaParallel.parse_command_line(["LimaParallel"]).mpi
 
     with pytest.raises(ValueError):
-        assert LimaSerial.parse_command_line(["LimaParallel", "--mpi"]).mpi
+        assert LimaSerial.parse_command_line(["LimaSerial", "--mpi"]).mpi
 
 
 # could add more tests here for constructor, but the regression tests here and in TXPipe are


### PR DESCRIPTION
Some stages have parallel=False set and so cannot be run under MPI. The current error message just says that there is no flag --mpi for the stage; this makes it a clearer message.