### PR TITLE
Add support for Perlmutter

### DIFF
--- a/ceci/sites/__init__.py
+++ b/ceci/sites/__init__.py
@@ -1,6 +1,6 @@
 """Classes and functions to manage site-specific configuration"""
 
-from .cori import CoriBatchSite, CoriInteractiveSite
+from .cori import NerscBatchSite, NerscInteractiveSite
 from .local import LocalSite, Site
 from .ccin2p3 import CCParallel
 import os
@@ -60,7 +60,7 @@ def load(launcher_config, site_configs):
         Configuration information on launchers (parsl, minirunner, CWL).
 
     site_configs: list[dict]
-        list of configs for different sites (local, cori-batch, cori-interactive).
+        list of configs for different sites (local, nersc-batch, nersc-interactive).
 
     """
     sites = []
@@ -72,7 +72,7 @@ def load(launcher_config, site_configs):
     for site_config in site_configs:
         site_name = site_config["name"]
         # Also tell the sites whether this is a dry-run.
-        # for example, the cori site checks you're not
+        # for example, the nersc site checks you're not
         # trying to run srun on a login node, but we skip
         # that test if we are not actually running the command,
         # just printing it.

--- a/ceci/sites/__init__.py
+++ b/ceci/sites/__init__.py
@@ -9,8 +9,10 @@ import os
 # Maps names from config files to classes.
 site_classes = {
     "local": LocalSite,
-    "cori-interactive": CoriInteractiveSite,
-    "cori-batch": CoriBatchSite,
+    "cori-interactive": NerscInteractiveSite,
+    "cori-batch": NerscBatchSite,
+    "nersc-interactive": NerscInteractiveSite,
+    "nersc-batch": NerscBatchSite,
     "cc-parallel": CCParallel,
 }
 


### PR DESCRIPTION
This updates the NERSC site so that it correctly detects the number of available cores on perlmutter as 128.  Since cori is retiring it also changes the language throughout to nersc instead of cori.  Using the name cori in configuration is still supported for legacy files though.