### PR TITLE
remove codecov dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dask = [
 
 test = [
     "pytest",
-    "codecov",
     "pytest-cov",
     "pytest-mock",
     "mockmpi",
@@ -85,7 +84,6 @@ all = [
     "cwl-utils",
     "pygraphviz",
     "pytest",
-    "codecov",
     "pytest-cov",
     "pytest-mock",
     "mockmpi",


### PR DESCRIPTION
Codecov was removed from pypi:
https://about.codecov.io/blog/message-regarding-the-pypi-package/

It looks like it shouldn't be needed here as we are using the action instead.