### PR TITLE
Abc meta classes

### DIFF
--- a/ceci/pipeline.py
+++ b/ceci/pipeline.py
@@ -5,7 +5,7 @@ import sys
 import collections
 import yaml
 import shutil
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from .stage import PipelineStage
 from . import minirunner
@@ -286,7 +286,7 @@ class FileManager(dict):
         return stage_outputs
 
 
-class Pipeline:
+class Pipeline(ABC):
     """
     The Pipeline base class models the shared information and behaviour
     that pipelines need, no matter which workflow manager runs them.

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -9,7 +9,7 @@ import cProfile
 import pdb
 import datetime
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from . import errors
 from .monitor import MemoryMonitor
 from .config import StageParameter, StageConfig, cast_to_streamable
@@ -21,7 +21,7 @@ DASK_PARALLEL = "dask"
 IN_PROGRESS_PREFIX = "inprogress_"
 
 
-class PipelineStage:
+class PipelineStage(ABC):
     """A PipelineStage implements a single calculation step within a wider pipeline.
 
     Each different type of analysis stage is represented by a subclass of this


### PR DESCRIPTION
This pull requests adds ``abc.ABC`` as meta classes for ``Pipeline`` and ``PipelineStage``.

Both classes implement a few abstract methods, however they do not use ``abc.ABC`` as meta class, which would prevent to instantiate a subclass if it does not properly implement the abstract methods. Currently a ``NotImplementedError`` is raised at a later point during runtime.