### PR TITLE
U/echarles/set site name

### DIFF
--- a/ceci/pipeline.py
+++ b/ceci/pipeline.py
@@ -865,7 +865,7 @@ Some required inputs to the pipeline could not be found,
         """Return true if we should skip a stage because it is finished and we are in resume mode"""
         return stage.should_skip(self.run_config)
 
-    def save(self, pipefile, stagefile=None, reduce_config=False):
+    def save(self, pipefile, stagefile=None, reduce_config=False, **kwargs):
         """Save this pipeline state to a yaml file
 
         Paramaeters
@@ -876,6 +876,12 @@ Some required inputs to the pipeline could not be found,
             Optional path to where we save the configuration file
         reduce_config: bool
             If true, reduce the configuration by parsing out the inputs, outputs and global params
+
+        
+        Keywords
+        --------
+        site_name: str
+            Used to override site name
         """
         pipe_dict = {}
         stage_dict = {}
@@ -924,6 +930,7 @@ Some required inputs to the pipeline could not be found,
         pipe_dict["inputs"] = self.overall_inputs
         pipe_dict["stages"] = pipe_info_list
         pipe_dict["site"] = site
+        pipe_dict["site"]["name"] = kwargs.get('site_name', local)
         with open(pipefile, "w") as outfile:
             try:
                 yaml.dump(pipe_dict, outfile)

--- a/ceci/pipeline.py
+++ b/ceci/pipeline.py
@@ -930,7 +930,7 @@ Some required inputs to the pipeline could not be found,
         pipe_dict["inputs"] = self.overall_inputs
         pipe_dict["stages"] = pipe_info_list
         pipe_dict["site"] = site
-        pipe_dict["site"]["name"] = kwargs.get('site_name', local)
+        pipe_dict["site"]["name"] = kwargs.get('site_name', 'local')
         with open(pipefile, "w") as outfile:
             try:
                 yaml.dump(pipe_dict, outfile)


### PR DESCRIPTION
A minor change to Pipeline.save() (which only gets used when making pipelines interactively).

1.  Set the site.name parameter to 'local' by default 
2. Allow it to be overridden using the site_name keyword argument.