### PR TITLE
Fix 2.0 bug with child class constructors

### DIFF
--- a/ceci/pipeline.py
+++ b/ceci/pipeline.py
@@ -194,7 +194,7 @@ class StageExecutionConfig:
             self.stage_obj = self.stage_class(args)
             self.stage_obj._aliases.update(**self.aliases)
             self.stage_obj._io_checked = False
-            self.stage_obj.check_io()
+        self.stage_obj.check_io()
         return self.stage_obj
 
     def generate_full_command(self, inputs, outputs, config):

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -181,7 +181,6 @@ class PipelineStage:
             error_class = type(error)
             msg = str(error)
             raise error_class(f"Error configuring {self.instance_name}: {msg}")
-        self.check_io(args)
 
     def check_io(self, args=None):
         """

--- a/ceci/update_pipelines_for_ceci_2.py
+++ b/ceci/update_pipelines_for_ceci_2.py
@@ -77,7 +77,8 @@ def update_pipeline_file_group(pipeline_files):
 def scan_directory_and_update(base_dir):
     groups = collections.defaultdict(list)
     yaml = ruamel.yaml.YAML()
-    for dirpath, subdirs, filenames in os.walk(base_dir):
+    yaml.allow_duplicate_keys
+    for dirpath, _, filenames in os.walk(base_dir):
         # just process yaml files
         for filename in filenames:
             if not (filename.endswith(".yaml") or filename.endswith(".yml")):
@@ -85,7 +86,11 @@ def scan_directory_and_update(base_dir):
             filepath = os.path.join(dirpath, filename)
             with open(filepath) as f:
                 yaml_str = f.read()
-            info = yaml.load(yaml_str)
+            try:
+                info = yaml.load(yaml_str)
+            except:
+                print("# Could not read yaml file:", filepath)
+                continue
 
             if is_pipeline_file(info):
                 config = info["config"]


### PR DESCRIPTION
RAIL classes with child constructors (many unnecessary) were crashing with the new code. The workaround was not quite working.