### PR TITLE
Validation step

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -150,7 +150,10 @@ class PipelineStage:
         raise NotImplementedError("run")
     
     def validate(self):
-        """Check that the inputs actually have the data needed for execution"""
+        """Check that the inputs actually have the data needed for execution,
+        This is called before the run method. It is an optional stage, meant
+        for checking that the input to the stage is actual in the form and
+        shape needed before an expensive run is executed."""
         pass 
 
     def load_configs(self, args):
@@ -670,8 +673,10 @@ I currently know about these stages:
         try:
             stage.validate()
         except Exception as error:
-            print(f"Looks like there is an validation error in: {cls.name}")
-            print(error)
+            if stage.rank==0:
+                print(f"Looks like there is an validation error in: {cls.name}",
+                        "the input data for this stage did not pass the checks implemented on it.")
+                print(error)
             raise
 
 

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -148,6 +148,10 @@ class PipelineStage:
     def run(self):  # pragma: no cover
         """Run the stage and return the execution status"""
         raise NotImplementedError("run")
+    
+    def validate(self):
+        """Check that the inputs actually have the data needed for execution"""
+        pass 
 
     def load_configs(self, args):
         """
@@ -660,6 +664,16 @@ I currently know about these stages:
 
         if args.memmon:  # pragma: no cover
             monitor = MemoryMonitor.start_in_thread(interval=args.memmon)
+
+        # Now we try to see if the validation step has been changed,
+        # if it has then we will run the validation step, and raise any errors
+        try:
+            stage.validate()
+        except Exception as error:
+            print(f"Looks like there is an validation error in: {cls.name}")
+            print(error)
+            raise
+
 
         try:
             stage.run()


### PR DESCRIPTION
The idea here is to add the option for a stage to test if the input it is supposed to run on actually have the data-structure the stage expects. 
The idea is that to any stage you can add a method `validate` that will be run before running the main `run` method of the stage. The idea is that the user can then write their own validation for each stage. If no `validate` step is done, it should just pass it by, and continue to the execute part. 
If an error is found in the validation it should raise an error and prevent an attempt to run the full stage and thereby waste lots of time. 
An example for use case would be in TXPipe where the stage `TXTwoPoint` requires the use of a _NofZ_ file, this file is only called at the end, and need to be structured in a specific way. The structure is something that has changed, and hence older files might not work, But you won't know until after several hours.