### PR TITLE
Add tracing feature

### DIFF
--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -14,6 +14,7 @@ from abc import abstractmethod
 from . import errors
 from .monitor import MemoryMonitor
 from .config import StageParameter, StageConfig, cast_to_streamable
+from .utils import activate_tracing
 
 SERIAL = "serial"
 MPI_PARALLEL = "mpi"
@@ -610,6 +611,12 @@ I currently know about these stages:
             help="Report memory use. Argument gives interval in seconds between reports",
         )
 
+        parser.add_argument(
+            "--trace",
+            action="store_true",
+            help="Enable sending a signal to the process that prints a trace wherever it is",
+        )
+
         # Error message we will return if --mpi used on a non-supported
         # stage.
         mpi_err = (
@@ -667,6 +674,9 @@ I currently know about these stages:
 
         if args.memmon:  # pragma: no cover
             monitor = MemoryMonitor.start_in_thread(interval=args.memmon)
+
+        if args.trace:
+            activate_tracing(stage._rank)
 
         # Now we try to see if the validation step has been changed,
         # if it has then we will run the validation step, and raise any errors

--- a/ceci/utils.py
+++ b/ceci/utils.py
@@ -3,6 +3,8 @@
 from contextlib import contextmanager
 import sys
 import os
+import signal
+import faulthandler
 
 
 def add_python_path(path, start):
@@ -107,3 +109,9 @@ def embolden(text):
         Emboldened text
     """
     return "\033[1m" + text + "\033[0m"
+
+
+def activate_tracing(rank):
+    pid = os.getpid()
+    print(f"Activating trace mode for process {rank}. Trigger trace using command: kill -s {signal.SIGUSR1} {pid}")
+    faulthandler.register(signal.SIGUSR1)

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -572,7 +572,7 @@ def test_wrong_mpi_flag():
     with pytest.raises(ValueError):
         assert LimaSerial.parse_command_line(["LimaSerial", "--mpi"]).mpi
 
-
+@pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS") == "true", reason="Doesn't work on github actions")
 def test_tracing():
     with open("mike_stage.py", "w") as f:
         f.write("""

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -585,7 +585,7 @@ class Mike(ceci.PipelineStage):
     config_options = {}
 
     def run(self):
-        time.sleep(3)
+        time.sleep(6)
         print("Mike complete")
 
 if __name__ == "__main__":
@@ -599,7 +599,7 @@ if __name__ == "__main__":
     time.sleep(1)
     p1.send_signal(signal.SIGUSR1)
     try:
-        outs, _ = p1.communicate(timeout=5)
+        outs, _ = p1.communicate(timeout=15)
     except subprocess.TimeoutExpired:
         p1.kill()
         outs, _ = p1.communicate()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -599,10 +599,9 @@ if __name__ == "__main__":
         cmd = f"{sys.executable} mike_stage.py Mike --config config.yml --trace"
         p1 = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         time.sleep(1)
-        cmd2 = f"kill -n {signal.SIGUSR1} {p1.pid}"
-        subprocess.check_call(cmd2, shell=True)
+        p1.send_signal(signal.SIGUSR1)
         try:
-            outs, _ = p1.communicate(timeout=6)
+            outs, _ = p1.communicate(timeout=5)
         except subprocess.TimeoutExpired:
             p1.kill()
             outs, _ = p1.communicate()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -572,12 +572,10 @@ def test_wrong_mpi_flag():
     with pytest.raises(ValueError):
         assert LimaSerial.parse_command_line(["LimaSerial", "--mpi"]).mpi
 
-def test_tracing():
-    with tempfile.TemporaryDirectory() as dirname:
-        os.chdir(dirname)
 
-        with open("mike_stage.py", "w") as f:
-            f.write("""
+def test_tracing():
+    with open("mike_stage.py", "w") as f:
+        f.write("""
 import ceci
 import time
 class Mike(ceci.PipelineStage):
@@ -593,20 +591,20 @@ class Mike(ceci.PipelineStage):
 if __name__ == "__main__":
     ceci.PipelineStage.main()
 """)
-        with open("config.yml", "w") as f:
-            f.write("{}")
+    with open("config.yml", "w") as f:
+        f.write("{}")
 
-        cmd = f"{sys.executable} mike_stage.py Mike --config config.yml --trace"
-        p1 = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        time.sleep(1)
-        p1.send_signal(signal.SIGUSR1)
-        try:
-            outs, _ = p1.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            p1.kill()
-            outs, _ = p1.communicate()
-            raise ValueError("Timeout expired in Mike test with outs =" + outs.decode())
-        assert 'mike_stage.py", line 15' in outs.decode()
+    cmd = f"{sys.executable} mike_stage.py Mike --config config.yml --trace"
+    p1 = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    time.sleep(1)
+    p1.send_signal(signal.SIGUSR1)
+    try:
+        outs, _ = p1.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        p1.kill()
+        outs, _ = p1.communicate()
+        raise ValueError("Timeout expired in Mike test with outs =" + outs.decode())
+    assert 'mike_stage.py", line 15' in outs.decode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This feature allows users to send a signal to running TXPipe processes that prints out the current python traceback without killing the process.

The test works locally but not on github actions; it looks like that's a limitation of their runners: https://github.com/orgs/community/discussions/25663