### PR TITLE
Add ability to open directories for parallel write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
   
     steps:
     - name: Checkout repository

--- a/ceci/file_types.py
+++ b/ceci/file_types.py
@@ -39,6 +39,11 @@ class DataFile:
         self.path = path
         self.mode = mode
 
+        # store whether we are in parallel mode
+        # for later use.
+        self.parallel = kwargs.get("parallel", False)
+        self.comm = kwargs.get("comm", None)
+
         if mode not in ["r", "w"]:
             raise ValueError(f"File 'mode' argument must be 'r' or 'w' not '{mode}'")
 
@@ -343,15 +348,24 @@ class YamlFile(DataFile):
 
 class Directory(DataFile):
     suffix = ""
+    supports_parallel_write = True
 
     @classmethod
-    def open(self, path, mode):
+    def open(self, path, mode, comm=None, parallel=False):
         p = pathlib.Path(path)
 
         if mode == "w":
-            if p.exists():
-                shutil.rmtree(p)
-            p.mkdir(parents=True)
+            # Make it so that only one process
+            # tries to create the directory if running
+            # in parallel
+            if (not parallel) or (parallel and comm.rank == 0):
+                if p.exists():
+                    shutil.rmtree(p)
+                p.mkdir(parents=True)
+            # Then once that one process as done it all the others
+            # should wait to avoid race conditions.
+            if parallel:
+                comm.Barrier()
         else:
             if not p.is_dir():
                 raise ValueError(f"Directory input {path} does not exist")
@@ -365,8 +379,13 @@ class Directory(DataFile):
         Write provenance information to a new group,
         called 'provenance'
         """
-        # This method *must* be called by all the processes in a parallel
-        # run.
+        # Directories can be opened in parallel, but only
+        # the rank 0 process should write the provenance.
+        # This is unlike HDF5 where all the processes have to
+        # cooperate to write it.
+        if (self.comm is not None) and (self.comm.rank != 0):
+            return
+
         if self.mode == "r":
             raise UnsupportedOperation(f"Cannot write provenance to a directory opened in read-only mode ({self.mode})")
 

--- a/ceci/stage.py
+++ b/ceci/stage.py
@@ -16,6 +16,7 @@ from . import errors
 from .monitor import MemoryMonitor
 from .config import StageParameter, StageConfig, cast_to_streamable
 from .utils import activate_tracing
+from . import file_types
 
 SERIAL = "serial"
 MPI_PARALLEL = "mpi"
@@ -1131,13 +1132,19 @@ I currently know about these stages:
         path = self.get_output(tag, final_name=final_name)
         output_class = self.get_output_type(tag)
 
-        # HDF files can be opened for parallel writing
+        # HDF files and directory outputs can be opened for parallel writing
         # under MPI.  This checks if:
         # - we have been told to open in parallel
         # - we are actually running under MPI
         # and adds the flags required if all these are true
         run_parallel = kwargs.pop("parallel", False) and self.is_mpi()
-        if run_parallel:
+        if run_parallel and issubclass(output_class, file_types.Directory):
+            kwargs["parallel"] = True
+            kwargs["comm"] = self.comm
+
+        # otherwise must be HDF5. Ideally we would check more carefully
+        # here, but I don't want to mess up any RAIL HDF stuff by accident.
+        elif run_parallel:
             kwargs["driver"] = "mpio"
             kwargs["comm"] = self.comm
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,24 @@
+import ceci.file_types as file_types
+import tempfile
+import os
+import mockmpi
+
+
+def _test_directory_parallel(comm, tmpdir):
+        print(comm.rank, tmpdir)
+        d = file_types.Directory(tmpdir + "/test_dir", "w", parallel=True, comm=comm)
+        comm.Barrier()
+        assert d.path == tmpdir + "/test_dir"
+        assert os.path.exists(tmpdir + "/test_dir/provenance.yml")
+
+
+def test_directory():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        d = file_types.Directory(tmpdir + "/test_dir", "w", parallel=False)
+        assert d.path == tmpdir + "/test_dir"
+        assert os.path.exists(tmpdir + "/test_dir/provenance.yml")
+
+
+def test_directory_parallel():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mockmpi.mock_mpiexec(2, _test_directory_parallel, tmpdir)


### PR DESCRIPTION
Directories can trivially be written to from parallel processes provided that the caller makes sure that only one process writes to a single file in them.

This would be trivial within ceci except that when a directory is an output object is opened for writing any existing directory there is removed and a new one created. If done in parallel this leads to race conditions where processes all try and delete and re-create it. Also, all the processes try to write provenance information to the directory.

This cleans things up allowing parallel directory writes.